### PR TITLE
build improvements and fixes

### DIFF
--- a/hbtui.hbc
+++ b/hbtui.hbc
@@ -5,8 +5,9 @@
 prgflags=-w3 -es2
 
 incpaths=include
-libpaths=lib/${hb_arch}/${hb_comp}
-libs=hbct hbtui
+libpaths=lib/${hb_plat}/${hb_comp}
+libs=hbtui
+hbcs=hbct.hbc
 
 {unix|linux|darwin}gt=gtxwc
 {win}gt=gtwvt

--- a/hbtui.hbp
+++ b/hbtui.hbp
@@ -10,13 +10,6 @@
 
 -iinclude
 
--instpath=${hb_lib}/
-
--instfile=inc:include/hbtui.ch
--instpath=inc:${hb_inc}/hbtui/
-
--instforce
-
 hbct.hbc
 
 src/*.c
@@ -25,3 +18,6 @@ src/types/*.prg
 src/HTEvent/*.prg
 src/HTEvent/HTInputEvent/*.prg
 src/HTWidget/*.prg
+
+$hb_pkg_dynlib.hbm
+$hb_pkg_install.hbm


### PR DESCRIPTION
- refer to hbct lib via its .hbc file
- rename deprecated, then removed ${hb_arch} to ${hb_plat}
  to fix finding the hbtui library via hbtui.hbc
- use hbmk2 builtin to install hbtui in Harbour's addons
  directory and let hbtui.hbc be found without a pathspec
- delete manual copying of files to Harbour folders.
  it should be unnecessary after above fixes
- use hbmk2 builtin to help building a dynamic lib using:
  `hbmk2 -hbdyn hbtui.hbp`
  (untested)
